### PR TITLE
corrected chrLen name filter

### DIFF
--- a/source/plot2DO_data.R
+++ b/source/plot2DO_data.R
@@ -189,7 +189,7 @@ LoadGenomeAnnotation_v2 <- function(inputFilename, genome){
            configFilePath <- file.path(configBasePath, "annotation_config.yaml")
            config <- yaml.load_file(configFilePath)
            chrFilter <- config$annotations[[genome]]$chromosome_size$filter
-           chrLen <- chrLen[chrFilter]
+           chrLen <- chrLen[names(chrLen) %in% chrFilter]
                       
            annotations <- GetAnnotations(genome)
            


### PR DESCRIPTION
I realised there is a problem with the annotation. 
When you load bam files which do not include all chromosomes annotated in the config (like with the sample bams) `NA` is introduced as chromosome name which later throws an error (`supplied 'seqlevels' cannot contain NAs or empty strings ("")`). 

I changed the code so it explicitly checks whether the chromosome names are listed in the filter or not. This omits the introduction of NAs. 
I am not sure whether the order of the chromosomes is important as my solution doesn't change that while the earlier code adjusted the order to the order specified in the annotation. So maybe the code has to be adjusted for that additionally.